### PR TITLE
fixed email URL

### DIFF
--- a/site/config.yaml
+++ b/site/config.yaml
@@ -165,7 +165,7 @@ params:
   - header: 'yes'
     icon: icon-mail
     title: email
-    url: team@lamyne.org
+    url: mailto:team@lamyne.org
   - icon: icon-social-youtube-outline
     title: youtube
     url: https://www.youtube.com/channel/UC-AkSeIOQf3-fscKmoXfmxA


### PR DESCRIPTION
when clicked, the current URL opens https://www.lamyne.org/team@lamyne.org instead of opening an email editor